### PR TITLE
fix typo in subscribe_to_system_event

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,7 +417,7 @@ impl SimConnector {
         }
     }
 
-    pub fn subcribe_to_system_event(&self, event_id: SIMCONNECT_CLIENT_EVENT_ID, event_name: &str) -> bool {
+    pub fn subscribe_to_system_event(&self, event_id: SIMCONNECT_CLIENT_EVENT_ID, event_name: &str) -> bool {
         unsafe {
             let result = SimConnect_SubscribeToSystemEvent(self.sim_connect_handle, event_id, as_c_string!(event_name));
             return result == 0;


### PR DESCRIPTION
Just fixing a minor typo, subcribe->subscribe.