### PR TITLE
Exposing the data definition epsilon variable plus fix example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "simconnect"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bindgen",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "simconnect"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "simconnect"
 license = "MIT"
 description = "Rust bindings for SimConnect"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Connor T"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,14 @@ authors = ["Connor T"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[[example]]
+name = "aircraft_updates_on_change_demo"
+path = "examples/aircraft_updates_on_change/main.rs"
+
+[[example]]
+name = "aircraft_updates"
+path = "examples/aircraft_updates/main.rs"
+
 
 [build-dependencies]
 bindgen = "0.65"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [[example]]
-name = "aircraft_updates_on_change_demo"
+name = "aircraft_updates_on_change"
 path = "examples/aircraft_updates_on_change/main.rs"
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "simconnect"
 license = "MIT"
 description = "Rust bindings for SimConnect"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Connor T"]
 edition = "2018"
 

--- a/Readme.md
+++ b/Readme.md
@@ -11,49 +11,24 @@ simconnect = "0.2.1"
 
 1. Install [CLang](https://clang.llvm.org/get_started.html). More information available at the [Rust Bindgen Documentation](https://rust-lang.github.io/rust-bindgen/requirements.html).
 2. run `cargo build`
-3. `use simconnect`
+3. Add `use simconnect` at the top of your file
 
-### Sample Program
-*Note: You must have SimConnect.dll in your current working directory or in the exe directory to be able to successfully use SimConnect*
-```rust
-use simconnect;
-use std::time::Duration;
-use std::thread::sleep;
-use std::mem::transmute_copy;
+## Example
+Read float position data
 
-struct DataStruct {
-  lat: f64,
-  lon: f64,
-  alt: f64,
-}
-
-let mut conn = simconnect::SimConnector::new();
-conn.connect("Simple Program"); // Intialize connection with SimConnect
-conn.add_data_definition(0, "PLANE LATITUDE", "Degrees", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX, 0.0); // Assign a sim variable to a client defined id
-conn.add_data_definition(0, "PLANE LONGITUDE", "Degrees", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX, 0.0);
-conn.add_data_definition(0, "PLANE ALTITUDE", "Feet", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX, 1.0); //define_id, units, data_type, datum_id, epsilon (update threshold)
-conn.request_data_on_sim_object(0, 0, 0, simconnect::SIMCONNECT_PERIOD_SIMCONNECT_PERIOD_SIM_FRAME, 0, 0, 0, 0); //request_id, define_id, object_id (user), period, falgs, origin, interval, limit - tells simconnect to send data for the defined id and on the user aircraft
-
-loop {
-  match conn.get_next_message() {
-    Ok(simconnect::DispatchResult::SimobjectData(data)) => {
-      unsafe {
-        match data.dwDefineID {
-          0 => {
-            let sim_data =  std::ptr::addr_of!(data.dwData);
-            let sim_data_ptr = sim_data as *const DataStruct;
-            let sim_data_value = std::ptr::read_unaligned(sim_data_ptr);
-            println!("{:?} {:?} {:?}", sim_data_value.lat, sim_data_value.lon, sim_data_value.alt);
-          },
-          _ => ()
-        }
-      }
-    },
-    _ => ()
-  }
-  
-  sleep(Duration::from_millis(16)); // Will use up lots of CPU if this is not included, as get_next_message() is non-blocking
-}
 ```
+cargo run --example aircraft_updates
+```
+
+Requests tagged data with thresholds from SimConnect and reads floats/strings
+```
+cargo run --example aircraft_updates_on_change_demo
+```
+
+*You must have SimConnect.dll in the same directory as the compiled exe for it to run (eg. in )*
+
+## Building
+*The SimConnect.dll is included in this repository, but might not be up to date*
+
 ### Remarks
 I have not tested every single function from the api. If you find an error, feel free to make an issue or a pull request.

--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,7 @@ simconnect = "0.2.1"
 ```
 
 ## Building
-*The SimConnect binaries are included within this repository, but they may not be up to date.*
+*The SimConnect binaries are included within this repository, but they may not be up-to-date.*
 
 1. Install [CLang](https://clang.llvm.org/get_started.html). More information available at the [Rust Bindgen Documentation](https://rust-lang.github.io/rust-bindgen/requirements.html).
 2. run `cargo build`
@@ -25,10 +25,10 @@ Requests tagged data with thresholds from SimConnect and reads floats/strings
 cargo run --example aircraft_updates_on_change
 ```
 
-*You must have SimConnect.dll in the same directory as the compiled exe for it to run (eg. in )*
+*You must have SimConnect.dll in the same directory as the compiled exe for it to run (e.g. in )*
 
 ## Building
-*The SimConnect.dll is included in this repository, but might not be up to date*
+*The SimConnect.dll is included in this repository, but might not be up-to-date*
 
 ### Remarks
 I have not tested every single function from the api. If you find an error, feel free to make an issue or a pull request.

--- a/Readme.md
+++ b/Readme.md
@@ -40,8 +40,10 @@ loop {
       unsafe {
         match data.dwDefineID {
           0 => {
-            let sim_data: DataStruct = transmute_copy(&data.dwData);
-            println!("{:?} {:?} {:?}", sim_data.lat, sim_data.lon, sim_data.alt);
+            let sim_data =  std::ptr::addr_of!(data.dwData);
+            let sim_data_ptr = sim_data as *const DataStruct;
+            let sim_data_value = std::ptr::read_unaligned(sim_data_ptr);
+            println!("{:?} {:?} {:?}", sim_data_value.lat, sim_data_value.lon, sim_data_value.alt);
           },
           _ => ()
         }

--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@
 Add this to your `Cargo.toml`
 ```toml
 [dependencies]
-simconnect = "0.2.0"
+simconnect = "0.2.1"
 ```
 
 ## Building

--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,7 @@ simconnect = "0.2.1"
 ```
 
 ## Building
-*The SimConnect binaries are included within this repository, but they may not be up to date.*
+*The SimConnect binaries are included within this repository, but they may not be up-to-date.*
 
 1. Install [CLang](https://clang.llvm.org/get_started.html). More information available at the [Rust Bindgen Documentation](https://rust-lang.github.io/rust-bindgen/requirements.html).
 2. run `cargo build`
@@ -28,11 +28,11 @@ struct DataStruct {
 }
 
 let mut conn = simconnect::SimConnector::new();
-conn.connect("Simple Program"); // Intialize connection with SimConnect
+conn.connect("Simple Program"); // Initialize connection with SimConnect
 conn.add_data_definition(0, "PLANE LATITUDE", "Degrees", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX, 0.0); // Assign a sim variable to a client defined id
 conn.add_data_definition(0, "PLANE LONGITUDE", "Degrees", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX, 0.0);
 conn.add_data_definition(0, "PLANE ALTITUDE", "Feet", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX, 1.0); //define_id, units, data_type, datum_id, epsilon (update threshold)
-conn.request_data_on_sim_object(0, 0, 0, simconnect::SIMCONNECT_PERIOD_SIMCONNECT_PERIOD_SIM_FRAME, 0, 0, 0, 0); //request_id, define_id, object_id (user), period, falgs, origin, interval, limit - tells simconnect to send data for the defined id and on the user aircraft
+conn.request_data_on_sim_object(0, 0, 0, simconnect::SIMCONNECT_PERIOD_SIMCONNECT_PERIOD_SIM_FRAME, 0, 0, 0, 0); //request_id, define_id, object_id (user), period, flags, origin, interval, limit - tells Simconnect to send data for the defined id and on the user aircraft
 
 loop {
   match conn.get_next_message() {
@@ -40,8 +40,7 @@ loop {
       unsafe {
         match data.dwDefineID {
           0 => {
-            let sim_data =  std::ptr::addr_of!(data.dwData);
-            let sim_data_ptr = sim_data as *const DataStruct;
+            let sim_data_ptr =  std::ptr::addr_of!(data.dwData) as *const DataStruct;
             let sim_data_value = std::ptr::read_unaligned(sim_data_ptr);
             println!("{:?} {:?} {:?}", sim_data_value.lat, sim_data_value.lon, sim_data_value.alt);
           },
@@ -55,5 +54,9 @@ loop {
   sleep(Duration::from_millis(16)); // Will use up lots of CPU if this is not included, as get_next_message() is non-blocking
 }
 ```
+### Examples
+You can find examples in the `examples` directory. To run them, you must have SimConnect.dll in your current working directory or in the exe directory.
+* `cargo run --example aircraft_updates` - Prints the user aircraft's latitude, longitude, and altitude on a interval
+* `cargo run --example aircraft_updates_on_change` - Prints the user aircraft's latitude, longitude, and altitude when the values change in SimConnect
 ### Remarks
 I have not tested every single function from the api. If you find an error, feel free to make an issue or a pull request.

--- a/Readme.md
+++ b/Readme.md
@@ -29,9 +29,9 @@ struct DataStruct {
 
 let mut conn = simconnect::SimConnector::new();
 conn.connect("Simple Program"); // Intialize connection with SimConnect
-conn.add_data_definition(0, "PLANE LATITUDE", "Degrees", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX); // Assign a sim variable to a client defined id
-conn.add_data_definition(0, "PLANE LONGITUDE", "Degrees", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX);
-conn.add_data_definition(0, "PLANE ALTITUDE", "Feet", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX); //define_id, units, data_type, datum_id
+conn.add_data_definition(0, "PLANE LATITUDE", "Degrees", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX, 0.0); // Assign a sim variable to a client defined id
+conn.add_data_definition(0, "PLANE LONGITUDE", "Degrees", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX, 0.0);
+conn.add_data_definition(0, "PLANE ALTITUDE", "Feet", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX, 1.0); //define_id, units, data_type, datum_id, epsilon (update threshold)
 conn.request_data_on_sim_object(0, 0, 0, simconnect::SIMCONNECT_PERIOD_SIMCONNECT_PERIOD_SIM_FRAME, 0, 0, 0, 0); //request_id, define_id, object_id (user), period, falgs, origin, interval, limit - tells simconnect to send data for the defined id and on the user aircraft
 
 loop {

--- a/examples/aircraft_updates/main.rs
+++ b/examples/aircraft_updates/main.rs
@@ -1,0 +1,38 @@
+use simconnect;
+use std::time::Duration;
+use std::thread::sleep;
+
+struct DataStruct {
+    lat: f64,
+    lon: f64,
+    alt: f64,
+}
+fn main() {
+    let mut conn = simconnect::SimConnector::new();
+    conn.connect("Simple Program"); // Intialize connection with SimConnect
+    conn.add_data_definition(0, "PLANE LATITUDE", "Degrees", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX, 0.0); // Assign a sim variable to a client defined id
+    conn.add_data_definition(0, "PLANE LONGITUDE", "Degrees", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX, 0.0);
+    conn.add_data_definition(0, "PLANE ALTITUDE", "Feet", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX, 1.0); //define_id, units, data_type, datum_id, epsilon (update threshold)
+    conn.request_data_on_sim_object(0, 0, 0, simconnect::SIMCONNECT_PERIOD_SIMCONNECT_PERIOD_SIM_FRAME, 0, 0, 0, 0); //request_id, define_id, object_id (user), period, falgs, origin, interval, limit - tells simconnect to send data for the defined id and on the user aircraft
+
+    loop {
+        match conn.get_next_message() {
+            Ok(simconnect::DispatchResult::SimobjectData(data)) => {
+                unsafe {
+                    match data.dwDefineID {
+                        0 => {
+                            let sim_data = std::ptr::addr_of!(data.dwData);
+                            let sim_data_ptr = sim_data as *const DataStruct;
+                            let sim_data_value = std::ptr::read_unaligned(sim_data_ptr);
+                            println!("{:?} {:?} {:?}", sim_data_value.lat, sim_data_value.lon, sim_data_value.alt);
+                        },
+                        _ => ()
+                    }
+                }
+            },
+            _ => ()
+        }
+
+        sleep(Duration::from_millis(16)); // Will use up lots of CPU if this is not included, as get_next_message() is non-blocking
+    }
+}

--- a/examples/aircraft_updates/main.rs
+++ b/examples/aircraft_updates/main.rs
@@ -48,7 +48,7 @@ fn main() {
 
     loop {
         match conn.get_next_message() {
-            Ok(DispatchResult::SimobjectData(data)) => unsafe {
+            Ok(DispatchResult::SimObjectData(data)) => unsafe {
                 if data.dwDefineID == 0 {
                     let sim_data_ptr = std::ptr::addr_of!(data.dwData) as *const DataStruct;
                     let sim_data_value = std::ptr::read_unaligned(sim_data_ptr);

--- a/examples/aircraft_updates/main.rs
+++ b/examples/aircraft_updates/main.rs
@@ -21,8 +21,7 @@ fn main() {
                 unsafe {
                     match data.dwDefineID {
                         0 => {
-                            let sim_data = std::ptr::addr_of!(data.dwData);
-                            let sim_data_ptr = sim_data as *const DataStruct;
+                            let sim_data_ptr =  std::ptr::addr_of!(data.dwData) as *const DataStruct;
                             let sim_data_value = std::ptr::read_unaligned(sim_data_ptr);
                             println!("{:?} {:?} {:?}", sim_data_value.lat, sim_data_value.lon, sim_data_value.alt);
                         },

--- a/examples/aircraft_updates/main.rs
+++ b/examples/aircraft_updates/main.rs
@@ -1,6 +1,7 @@
-use simconnect;
-use std::time::Duration;
 use std::thread::sleep;
+use std::time::Duration;
+
+use simconnect::DispatchResult;
 
 struct DataStruct {
     lat: f64,
@@ -10,26 +11,60 @@ struct DataStruct {
 fn main() {
     let mut conn = simconnect::SimConnector::new();
     conn.connect("Simple Program"); // Intialize connection with SimConnect
-    conn.add_data_definition(0, "PLANE LATITUDE", "Degrees", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX, 0.0); // Assign a sim variable to a client defined id
-    conn.add_data_definition(0, "PLANE LONGITUDE", "Degrees", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX, 0.0);
-    conn.add_data_definition(0, "PLANE ALTITUDE", "Feet", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX, 1.0); //define_id, units, data_type, datum_id, epsilon (update threshold)
-    conn.request_data_on_sim_object(0, 0, 0, simconnect::SIMCONNECT_PERIOD_SIMCONNECT_PERIOD_SIM_FRAME, 0, 0, 0, 0); //request_id, define_id, object_id (user), period, falgs, origin, interval, limit - tells simconnect to send data for the defined id and on the user aircraft
+    conn.add_data_definition(
+        0,
+        "PLANE LATITUDE",
+        "Degrees",
+        simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64,
+        u32::MAX,
+        0.0,
+    ); // Assign a sim variable to a client defined id
+    conn.add_data_definition(
+        0,
+        "PLANE LONGITUDE",
+        "Degrees",
+        simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64,
+        u32::MAX,
+        0.0,
+    );
+    conn.add_data_definition(
+        0,
+        "PLANE ALTITUDE",
+        "Feet",
+        simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64,
+        u32::MAX,
+        1.0,
+    ); //define_id, units, data_type, datum_id, epsilon (update threshold)
+    conn.request_data_on_sim_object(
+        0,
+        0,
+        0,
+        simconnect::SIMCONNECT_PERIOD_SIMCONNECT_PERIOD_SIM_FRAME,
+        0,
+        0,
+        0,
+        0,
+    ); //request_id, define_id, object_id (user), period, falgs, origin, interval, limit - tells simconnect to send data for the defined id and on the user aircraft
 
     loop {
         match conn.get_next_message() {
-            Ok(simconnect::DispatchResult::SimobjectData(data)) => {
-                unsafe {
-                    match data.dwDefineID {
-                        0 => {
-                            let sim_data_ptr =  std::ptr::addr_of!(data.dwData) as *const DataStruct;
-                            let sim_data_value = std::ptr::read_unaligned(sim_data_ptr);
-                            println!("{:?} {:?} {:?}", sim_data_value.lat, sim_data_value.lon, sim_data_value.alt);
-                        },
-                        _ => ()
-                    }
+            Ok(DispatchResult::SimobjectData(data)) => unsafe {
+                if data.dwDefineID == 0 {
+                    let sim_data_ptr = std::ptr::addr_of!(data.dwData) as *const DataStruct;
+                    let sim_data_value = std::ptr::read_unaligned(sim_data_ptr);
+                    println!(
+                        "{:?} {:?} {:?}",
+                        sim_data_value.lat, sim_data_value.lon, sim_data_value.alt
+                    );
                 }
             },
-            _ => ()
+            Ok(DispatchResult::Open(_)) => {
+                println!("Connected to simulator.");
+            }
+            Ok(DispatchResult::Quit(_)) => {
+                println!("Disconnected from simulator.");
+            }
+            _ => (),
         }
 
         sleep(Duration::from_millis(16)); // Will use up lots of CPU if this is not included, as get_next_message() is non-blocking

--- a/examples/aircraft_updates_on_change/main.rs
+++ b/examples/aircraft_updates_on_change/main.rs
@@ -1,7 +1,6 @@
-use simconnect;
-use simconnect::DWORD;
-use std::time::Duration;
+use simconnect::{DispatchResult, DWORD};
 use std::thread::sleep;
+use std::time::Duration;
 
 // To allign the memory we have to set a fixed max size to the returned variables from the game
 const MAX_RETURNED_ITEMS: usize = 255;
@@ -11,10 +10,10 @@ const MAX_RETURNED_ITEMS: usize = 255;
 #[repr(C, packed)]
 struct KeyValuePairFloat {
     id: DWORD,
-    value: f64
+    value: f64,
 }
 struct DataFloatStruct {
-    data: [KeyValuePairFloat; MAX_RETURNED_ITEMS]
+    data: [KeyValuePairFloat; MAX_RETURNED_ITEMS],
 }
 #[repr(C, packed)]
 struct KeyValuePairString {
@@ -24,7 +23,7 @@ struct KeyValuePairString {
 }
 
 struct DataStringStruct {
-    data: [KeyValuePairString; MAX_RETURNED_ITEMS]
+    data: [KeyValuePairString; MAX_RETURNED_ITEMS],
 }
 
 fn main() {
@@ -37,68 +36,122 @@ fn main() {
     // This greatly reduces the amount of data send to your client
     // In this example the lat, lon values get an update every degree while the altitude only gets an
     // update every 100 feet
-    conn.add_data_definition(0, "PLANE LATITUDE", "Degrees", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, 1, 1.0); // Assign a sim variable to a client defined id
-    conn.add_data_definition(0, "PLANE LONGITUDE", "Degrees", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, 2, 1.0);
-    conn.add_data_definition(0, "PLANE ALTITUDE", "Feet", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, 3, 100.0); //define_id, units, data_type, datum_id, epsilon (update threshold)
+    conn.add_data_definition(
+        0,
+        "PLANE LATITUDE",
+        "Degrees",
+        simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64,
+        1,
+        1.0,
+    ); // Assign a sim variable to a client defined id
+    conn.add_data_definition(
+        0,
+        "PLANE LONGITUDE",
+        "Degrees",
+        simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64,
+        2,
+        1.0,
+    );
+    conn.add_data_definition(
+        0,
+        "PLANE ALTITUDE",
+        "Feet",
+        simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64,
+        3,
+        100.0,
+    ); //define_id, units, data_type, datum_id, epsilon (update threshold)
 
     // Here we define all our variabes that get returned as Strings
     // Notice how the define_id differs from the float values
     // This variable returns the name of the plane found in the aircraft.cfg (max 255 characters)
-    conn.add_data_definition(1, "TITLE", "", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_STRING256, 4, 0.0);
+    conn.add_data_definition(
+        1,
+        "TITLE",
+        "",
+        simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_STRING256,
+        4,
+        0.0,
+    );
 
     // Request the data from define_id 0 (floats) and only return the value if the value has changed including the id we passed in the datum_id
     // So if the latitude changes we receive: key 1 value X, if the longitude changes we receive key 2 value X.
     // If both have changed we receive both variables in an packed array.
     // The amount of variables returned is defined in the data.dwDefineCount of the response
-    conn.request_data_on_sim_object(0, 0, 0, simconnect::SIMCONNECT_PERIOD_SIMCONNECT_PERIOD_SIM_FRAME, simconnect::SIMCONNECT_CLIENT_DATA_REQUEST_FLAG_CHANGED | simconnect::SIMCONNECT_CLIENT_DATA_REQUEST_FLAG_TAGGED, 0, 0, 0); //request_id, define_id, object_id (user), period, falgs, origin, interval, limit - tells simconnect to send data for the defined id and on the user aircraft
-    // Request the data from our define_id 1 (strings)
-    // The request_id has to differ from the float request. Or else it will overwrite the previous request
-    conn.request_data_on_sim_object(1, 1, 0, simconnect::SIMCONNECT_PERIOD_SIMCONNECT_PERIOD_SIM_FRAME, simconnect::SIMCONNECT_CLIENT_DATA_REQUEST_FLAG_CHANGED | simconnect::SIMCONNECT_CLIENT_DATA_REQUEST_FLAG_TAGGED, 0, 0, 0); //request_id, define_id, object_id (user), period, falgs, origin, interval, limit - tells simconnect to send data for the defined id and on the user aircraft
+    conn.request_data_on_sim_object(
+        0,
+        0,
+        0,
+        simconnect::SIMCONNECT_PERIOD_SIMCONNECT_PERIOD_SIM_FRAME,
+        simconnect::SIMCONNECT_CLIENT_DATA_REQUEST_FLAG_CHANGED
+            | simconnect::SIMCONNECT_CLIENT_DATA_REQUEST_FLAG_TAGGED,
+        0,
+        0,
+        0,
+    ); //request_id, define_id, object_id (user), period, falgs, origin, interval, limit - tells simconnect to send data for the defined id and on the user aircraft
+       // Request the data from our define_id 1 (strings)
+       // The request_id has to differ from the float request. Or else it will overwrite the previous request
+    conn.request_data_on_sim_object(
+        1,
+        1,
+        0,
+        simconnect::SIMCONNECT_PERIOD_SIMCONNECT_PERIOD_SIM_FRAME,
+        simconnect::SIMCONNECT_CLIENT_DATA_REQUEST_FLAG_CHANGED
+            | simconnect::SIMCONNECT_CLIENT_DATA_REQUEST_FLAG_TAGGED,
+        0,
+        0,
+        0,
+    ); //request_id, define_id, object_id (user), period, falgs, origin, interval, limit - tells simconnect to send data for the defined id and on the user aircraft
 
     loop {
         match conn.get_next_message() {
-            Ok(simconnect::DispatchResult::SimobjectData(data)) => {
-                unsafe {
-                    match data.dwDefineID {
-                        // Here we match the define_id we've passed using the request_data_on_sim_object
-                        0 => {
-                            let sim_data_ptr =  std::ptr::addr_of!(data.dwData) as *const DataFloatStruct;
-                            let sim_data_value = std::ptr::read_unaligned(sim_data_ptr);
-                            // The amount of floats received from the sim
-                            let count = data.dwDefineCount as usize;
+            Ok(DispatchResult::SimobjectData(data)) => unsafe {
+                match data.dwDefineID {
+                    // Here we match the define_id we've passed using the request_data_on_sim_object
+                    0 => {
+                        let sim_data_ptr =
+                            std::ptr::addr_of!(data.dwData) as *const DataFloatStruct;
+                        let sim_data_value = std::ptr::read_unaligned(sim_data_ptr);
+                        // The amount of floats received from the sim
+                        let count = data.dwDefineCount as usize;
 
-                            // iterate through the array of data structs
-                            // To align the memory we have allocated an array of 255 elements to the datastruct
-                            // The game might return 255 or 2 values
-                            // To only iterate over valid elements in the array
-                            // We are able to leverage the dwDefineCount to loop over valid elements
-                            for i in 0..count {
-                                let value = sim_data_value.data[i].value;
-                                let key = sim_data_value.data[i].id;
-                                println!("{}", key.to_string());
-                                println!("{}", value);
-                            }
-                        },
-                        1 => {
-                            let sim_data_ptr =  std::ptr::addr_of!(data.dwData) as *const DataStringStruct;
-                            // The amount of strings received from the sim
-                            let count = data.dwDefineCount as usize;
-                            let sim_data_value = std::ptr::read_unaligned(sim_data_ptr);
-                            for i in 0..count {
-                                //since we only defined 1 string variable the key returned should be 4
-                                let key = sim_data_value.data[0].id;
-                                //byte array to string
-                                let string = std::str::from_utf8(&sim_data_value.data[i].value).unwrap();
-                                println!("{}", key.to_string());
-                                println!("{}", string);
-                            }
-
+                        // iterate through the array of data structs
+                        // To align the memory we have allocated an array of 255 elements to the datastruct
+                        // The game might return 255 or 2 values
+                        // To only iterate over valid elements in the array
+                        // We are able to leverage the dwDefineCount to loop over valid elements
+                        for i in 0..count {
+                            let value = sim_data_value.data[i].value;
+                            let key = sim_data_value.data[i].id;
+                            println!("{}", key);
+                            println!("{}", value);
                         }
-                        _ => ()
                     }
+                    1 => {
+                        let sim_data_ptr =
+                            std::ptr::addr_of!(data.dwData) as *const DataStringStruct;
+                        // The amount of strings received from the sim
+                        let count = data.dwDefineCount as usize;
+                        let sim_data_value = std::ptr::read_unaligned(sim_data_ptr);
+                        for i in 0..count {
+                            //since we only defined 1 string variable the key returned should be 4
+                            let key = sim_data_value.data[0].id;
+                            //byte array to string
+                            let string =
+                                std::str::from_utf8(&sim_data_value.data[i].value).unwrap();
+                            println!("{}", key);
+                            println!("{}", string);
+                        }
+                    }
+                    _ => (),
                 }
             },
-            _ => ()
+            Ok(DispatchResult::Open(_)) => {
+                println!("Connected to simulator.");
+            }
+            Ok(DispatchResult::Quit(_)) => {
+                println!("Disconnected from simulator.");
+            }
+            _ => (),
         }
 
         sleep(Duration::from_millis(16)); // Will use up lots of CPU if this is not included, as get_next_message() is non-blocking

--- a/examples/aircraft_updates_on_change/main.rs
+++ b/examples/aircraft_updates_on_change/main.rs
@@ -1,0 +1,100 @@
+use simconnect;
+use simconnect::DWORD;
+use std::time::Duration;
+use std::thread::sleep;
+
+// To allign the memory we have to set a fixed max size to the returned variables from the game
+const MAX_RETURNED_ITEMS: usize = 255;
+
+#[repr(C, packed)]
+struct KeyValuePairFloat {
+    id: DWORD,
+    value: f64
+}
+struct DataFloatStruct {
+    data: [KeyValuePairFloat; MAX_RETURNED_ITEMS]
+}
+#[repr(C, packed)]
+struct KeyValuePairString {
+    id: DWORD,
+    // Strings get returned as max 255 bytes
+    value: [u8; 255],
+}
+
+struct DataStringStruct {
+    data: [KeyValuePairString; MAX_RETURNED_ITEMS]
+}
+
+fn main() {
+    let mut conn = simconnect::SimConnector::new();
+    conn.connect("Program that returns data on changes"); // Intialize connection with SimConnect
+
+    // Here we define all our variable that get returned as floats
+    // (including integers, the memory allignment will handle the)
+    conn.add_data_definition(0, "PLANE LATITUDE", "Degrees", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, 1, 1.0); // Assign a sim variable to a client defined id
+    conn.add_data_definition(0, "PLANE LONGITUDE", "Degrees", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, 2, 1.0);
+    conn.add_data_definition(0, "PLANE ALTITUDE", "Feet", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, 3, 1.0); //define_id, units, data_type, datum_id, epsilon (update threshold)
+
+    // Here we define all our variabes that get returned as Strings
+    // Notice how the define_id differs from the float values
+    // This variable returns the name of the plane found in the aircraft.cfg (max 255 characters)
+    conn.add_data_definition(1, "TITLE", "", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_STRING256, 4, 0.0);
+
+    // Request the data from define_id 0 (floats) and only return the value if the value has changed including the id we passed in the datum_id
+    // So if the latitude changes we receive: key 1 value X, if the longitude changes we receive key 2 value X.
+    // If both have changed we receive both variables in an packed array.
+    // The amount of variables returned is defined in the data.dwDefineCount of the response
+    conn.request_data_on_sim_object(0, 0, 0, simconnect::SIMCONNECT_PERIOD_SIMCONNECT_PERIOD_SIM_FRAME, simconnect::SIMCONNECT_CLIENT_DATA_REQUEST_FLAG_CHANGED | simconnect::SIMCONNECT_CLIENT_DATA_REQUEST_FLAG_TAGGED, 0, 0, 0); //request_id, define_id, object_id (user), period, falgs, origin, interval, limit - tells simconnect to send data for the defined id and on the user aircraft
+    // Request the data from our define_id 1 (strings)
+    conn.request_data_on_sim_object(1, 1, 0, simconnect::SIMCONNECT_PERIOD_SIMCONNECT_PERIOD_SIM_FRAME, simconnect::SIMCONNECT_CLIENT_DATA_REQUEST_FLAG_CHANGED | simconnect::SIMCONNECT_CLIENT_DATA_REQUEST_FLAG_TAGGED, 0, 0, 0); //request_id, define_id, object_id (user), period, falgs, origin, interval, limit - tells simconnect to send data for the defined id and on the user aircraft
+
+    loop {
+        match conn.get_next_message() {
+            Ok(simconnect::DispatchResult::SimobjectData(data)) => {
+                unsafe {
+                    match data.dwDefineID {
+                        0 => {
+                            let sim_data =  std::ptr::addr_of!(data.dwData);
+                            let sim_data_ptr = sim_data as *const DataFloatStruct;
+                            let sim_data_value = std::ptr::read_unaligned(sim_data_ptr);
+                            // The amount of floats received from the sim
+                            let count = data.dwDefineCount as usize;
+
+                            // itterate through the array of data structs
+                            // To allign the memory we have allocated an array of 255 elements to the datastruct
+                            // The game might return 255 or 2 values
+                            // To only itterate over valid elements in the array
+                            // We are able to leverage the dwDefineCount to loop over valid elements
+                            for i in 0..count {
+                                let value = sim_data_value.data[i].value;
+                                let key = sim_data_value.data[i].id;
+                                println!("{}", key.to_string());
+                                println!("{}", value);
+                            }
+                        },
+                        1 => {
+                            let sim_data =  std::ptr::addr_of!(data.dwData);
+                            let sim_data_ptr = sim_data as *const DataStringStruct;
+                            // The amount of strings received from the sim
+                            let count = data.dwDefineCount as usize;
+                            let sim_data_value = std::ptr::read_unaligned(sim_data_ptr);
+                            for i in 0..count {
+                                //since we only defined 1 string variable the key returned should be 4
+                                let key = sim_data_value.data[0].id;
+                                //byte array to string
+                                let string = std::str::from_utf8(&sim_data_value.data[i].value).unwrap();
+                                println!("{}", key.to_string());
+                                println!("{}", string);
+                            }
+
+                        }
+                        _ => ()
+                    }
+                }
+            },
+            _ => ()
+        }
+
+        sleep(Duration::from_millis(16)); // Will use up lots of CPU if this is not included, as get_next_message() is non-blocking
+    }
+}

--- a/examples/aircraft_updates_on_change/main.rs
+++ b/examples/aircraft_updates_on_change/main.rs
@@ -50,6 +50,7 @@ fn main() {
     // The amount of variables returned is defined in the data.dwDefineCount of the response
     conn.request_data_on_sim_object(0, 0, 0, simconnect::SIMCONNECT_PERIOD_SIMCONNECT_PERIOD_SIM_FRAME, simconnect::SIMCONNECT_CLIENT_DATA_REQUEST_FLAG_CHANGED | simconnect::SIMCONNECT_CLIENT_DATA_REQUEST_FLAG_TAGGED, 0, 0, 0); //request_id, define_id, object_id (user), period, falgs, origin, interval, limit - tells simconnect to send data for the defined id and on the user aircraft
     // Request the data from our define_id 1 (strings)
+    // The request_id has to differ from the float request. Or else it will overwrite the previous request
     conn.request_data_on_sim_object(1, 1, 0, simconnect::SIMCONNECT_PERIOD_SIMCONNECT_PERIOD_SIM_FRAME, simconnect::SIMCONNECT_CLIENT_DATA_REQUEST_FLAG_CHANGED | simconnect::SIMCONNECT_CLIENT_DATA_REQUEST_FLAG_TAGGED, 0, 0, 0); //request_id, define_id, object_id (user), period, falgs, origin, interval, limit - tells simconnect to send data for the defined id and on the user aircraft
 
     loop {
@@ -57,6 +58,7 @@ fn main() {
             Ok(simconnect::DispatchResult::SimobjectData(data)) => {
                 unsafe {
                     match data.dwDefineID {
+                        //Here we match the define_id we've passed using the request_data_on_sim_object
                         0 => {
                             let sim_data =  std::ptr::addr_of!(data.dwData);
                             let sim_data_ptr = sim_data as *const DataFloatStruct;

--- a/examples/aircraft_updates_on_change/main.rs
+++ b/examples/aircraft_updates_on_change/main.rs
@@ -7,7 +7,7 @@ use std::thread::sleep;
 const MAX_RETURNED_ITEMS: usize = 255;
 
 // Rust will add padding to the inner parts of a struct if it isn't marked as packed
-// The way simconnect returns values is unalligned data in C style
+// The way Simconnect returns values is unaligned data in C style
 #[repr(C, packed)]
 struct KeyValuePairFloat {
     id: DWORD,
@@ -32,7 +32,7 @@ fn main() {
     conn.connect("Program that returns data on changes"); // Intialize connection with SimConnect
 
     // Here we define all our variable that get returned as floats
-    // (including integers, the memory allignment will handle the)
+    // (including integers, which the memory alignment will handle)
     // The epsilon determines per X change do we want to receive an update from the game
     // This greatly reduces the amount of data send to your client
     // In this example the lat, lon values get an update every degree while the altitude only gets an
@@ -60,18 +60,17 @@ fn main() {
             Ok(simconnect::DispatchResult::SimobjectData(data)) => {
                 unsafe {
                     match data.dwDefineID {
-                        //Here we match the define_id we've passed using the request_data_on_sim_object
+                        // Here we match the define_id we've passed using the request_data_on_sim_object
                         0 => {
-                            let sim_data =  std::ptr::addr_of!(data.dwData);
-                            let sim_data_ptr = sim_data as *const DataFloatStruct;
+                            let sim_data_ptr =  std::ptr::addr_of!(data.dwData) as *const DataFloatStruct;
                             let sim_data_value = std::ptr::read_unaligned(sim_data_ptr);
                             // The amount of floats received from the sim
                             let count = data.dwDefineCount as usize;
 
-                            // itterate through the array of data structs
-                            // To allign the memory we have allocated an array of 255 elements to the datastruct
+                            // iterate through the array of data structs
+                            // To align the memory we have allocated an array of 255 elements to the datastruct
                             // The game might return 255 or 2 values
-                            // To only itterate over valid elements in the array
+                            // To only iterate over valid elements in the array
                             // We are able to leverage the dwDefineCount to loop over valid elements
                             for i in 0..count {
                                 let value = sim_data_value.data[i].value;
@@ -81,8 +80,7 @@ fn main() {
                             }
                         },
                         1 => {
-                            let sim_data =  std::ptr::addr_of!(data.dwData);
-                            let sim_data_ptr = sim_data as *const DataStringStruct;
+                            let sim_data_ptr =  std::ptr::addr_of!(data.dwData) as *const DataStringStruct;
                             // The amount of strings received from the sim
                             let count = data.dwDefineCount as usize;
                             let sim_data_value = std::ptr::read_unaligned(sim_data_ptr);

--- a/examples/aircraft_updates_on_change/main.rs
+++ b/examples/aircraft_updates_on_change/main.rs
@@ -31,9 +31,13 @@ fn main() {
 
     // Here we define all our variable that get returned as floats
     // (including integers, the memory allignment will handle the)
+    // The epsilon determines per X change do we want to receive an update from the game
+    // This greatly reduces the amount of data send to your client
+    // In this example the lat, lon values get an update every degree while the altitude only gets an
+    // update every 100 feet
     conn.add_data_definition(0, "PLANE LATITUDE", "Degrees", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, 1, 1.0); // Assign a sim variable to a client defined id
     conn.add_data_definition(0, "PLANE LONGITUDE", "Degrees", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, 2, 1.0);
-    conn.add_data_definition(0, "PLANE ALTITUDE", "Feet", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, 3, 1.0); //define_id, units, data_type, datum_id, epsilon (update threshold)
+    conn.add_data_definition(0, "PLANE ALTITUDE", "Feet", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, 3, 100.0); //define_id, units, data_type, datum_id, epsilon (update threshold)
 
     // Here we define all our variabes that get returned as Strings
     // Notice how the define_id differs from the float values

--- a/examples/aircraft_updates_on_change/main.rs
+++ b/examples/aircraft_updates_on_change/main.rs
@@ -29,7 +29,7 @@ struct DataStringStruct {
 
 fn main() {
     let mut conn = simconnect::SimConnector::new();
-    conn.connect("Program that returns data on changes"); // Intialize connection with SimConnect
+    conn.connect("Program that returns data on changes"); // Initialize connection with SimConnect
 
     // Here we define all our variable that get returned as floats
     // (including integers, which the memory alignment will handle)

--- a/examples/aircraft_updates_on_change/main.rs
+++ b/examples/aircraft_updates_on_change/main.rs
@@ -6,6 +6,8 @@ use std::thread::sleep;
 // To allign the memory we have to set a fixed max size to the returned variables from the game
 const MAX_RETURNED_ITEMS: usize = 255;
 
+// Rust will add padding to the inner parts of a struct if it isn't marked as packed
+// The way simconnect returns values is unalligned data in C style
 #[repr(C, packed)]
 struct KeyValuePairFloat {
     id: DWORD,

--- a/examples/aircraft_updates_on_change/main.rs
+++ b/examples/aircraft_updates_on_change/main.rs
@@ -104,7 +104,7 @@ fn main() {
 
     loop {
         match conn.get_next_message() {
-            Ok(DispatchResult::SimobjectData(data)) => unsafe {
+            Ok(DispatchResult::SimObjectData(data)) => unsafe {
                 match data.dwDefineID {
                     // Here we match the define_id we've passed using the request_data_on_sim_object
                     0 => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,9 +27,9 @@ struct DataStruct {
 
 let mut conn = simconnect::SimConnector::new();
 conn.connect("Simple Program"); // Intialize connection with SimConnect
-conn.add_data_definition(0, "PLANE LATITUDE", "Degrees", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX); // Assign a sim variable to a client defined id
-conn.add_data_definition(0, "PLANE LONGITUDE", "Degrees", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX);
-conn.add_data_definition(0, "PLANE ALTITUDE", "Feet", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX); //define_id, units, data_type, datum_id
+conn.add_data_definition(0, "PLANE LATITUDE", "Degrees", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX, 0.0); // Assign a sim variable to a client defined id
+conn.add_data_definition(0, "PLANE LONGITUDE", "Degrees", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX, 0.0);
+conn.add_data_definition(0, "PLANE ALTITUDE", "Feet", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX, 0.0); //define_id, units, data_type, datum_id, epsilon (per X change in sim variable, send data)
 conn.request_data_on_sim_object(0, 0, 0, simconnect::SIMCONNECT_PERIOD_SIMCONNECT_PERIOD_SIM_FRAME, 0, 0, 0, 0); //request_id, define_id, object_id (user), period, falgs, origin, interval, limit - tells simconnect to send data for the defined id and on the user aircraft
 
 loop {
@@ -153,7 +153,7 @@ impl SimConnector {
                 as_c_string!(datum_name),
                 as_c_string!(units_name),
                 datum_type,
-                epsilon,
+                0.0,
                 datum_id,
             ) == 0
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,16 +59,11 @@ loop {
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
+use std::ffi::CString;
 use std::mem::transmute_copy;
 use std::ptr;
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
-
-macro_rules! as_c_string {
-    ($target:expr) => {
-        std::ffi::CString::new($target).unwrap().as_ptr()
-    };
-}
 
 /// Enumerations for all the possible data types received from SimConnect
 #[derive(Debug)]
@@ -126,9 +121,11 @@ impl SimConnector {
             let temp_1 = ptr::null_mut();
             let temp_2 = ptr::null_mut();
 
+            let program_name = CString::new(program_name).unwrap();
+
             SimConnect_Open(
                 &mut self.sim_connect_handle,
-                as_c_string!(program_name),
+                program_name.as_ptr(),
                 temp_1,
                 0,
                 temp_2,
@@ -148,12 +145,15 @@ impl SimConnector {
         datum_id: DWORD,
         epsilon: f32,
     ) -> bool {
+        let datum_name = CString::new(datum_name).unwrap();
+        let units_name = CString::new(units_name).unwrap();
+
         unsafe {
             SimConnect_AddToDataDefinition(
                 self.sim_connect_handle,
                 define_id,
-                as_c_string!(datum_name),
-                as_c_string!(units_name),
+                datum_name.as_ptr(),
+                units_name.as_ptr(),
                 datum_type,
                 epsilon,
                 datum_id,
@@ -229,11 +229,13 @@ impl SimConnector {
         group_id: SIMCONNECT_INPUT_GROUP_ID,
         input_definition: &str,
     ) -> bool {
+        let input_definition = CString::new(input_definition).unwrap();
+
         unsafe {
             SimConnect_RemoveInputEvent(
                 self.sim_connect_handle,
                 group_id,
-                as_c_string!(input_definition),
+                input_definition.as_ptr(),
             ) == 0
         }
     }
@@ -249,13 +251,17 @@ impl SimConnector {
         key_choice_2: &str,
         key_choice_3: &str,
     ) -> bool {
+        let key_choice_1 = CString::new(key_choice_1).unwrap();
+        let key_choice_2 = CString::new(key_choice_2).unwrap();
+        let key_choice_3 = CString::new(key_choice_3).unwrap();
+
         unsafe {
             SimConnect_RequestReservedKey(
                 self.sim_connect_handle,
                 event_id,
-                as_c_string!(key_choice_1),
-                as_c_string!(key_choice_2),
-                as_c_string!(key_choice_3),
+                key_choice_1.as_ptr(),
+                key_choice_2.as_ptr(),
+                key_choice_3.as_ptr(),
             ) == 0
         }
     }
@@ -271,12 +277,16 @@ impl SimConnector {
         airport_id: &str,
         request_id: SIMCONNECT_DATA_REQUEST_ID,
     ) -> bool {
+        let container_title = CString::new(container_title).unwrap();
+        let tail_number = CString::new(tail_number).unwrap();
+        let airport_id = CString::new(airport_id).unwrap();
+
         unsafe {
             SimConnect_AICreateParkedATCAircraft(
                 self.sim_connect_handle,
-                as_c_string!(container_title),
-                as_c_string!(tail_number),
-                as_c_string!(airport_id),
+                container_title.as_ptr(),
+                tail_number.as_ptr(),
+                airport_id.as_ptr(),
                 request_id,
             ) == 0
         }
@@ -292,13 +302,17 @@ impl SimConnector {
         touch_and_go: bool,
         request_id: SIMCONNECT_DATA_REQUEST_ID,
     ) -> bool {
+        let container_title = CString::new(container_title).unwrap();
+        let tail_number = CString::new(tail_number).unwrap();
+        let flight_plan_path = CString::new(flight_plan_path).unwrap();
+
         unsafe {
             SimConnect_AICreateEnrouteATCAircraft(
                 self.sim_connect_handle,
-                as_c_string!(container_title),
-                as_c_string!(tail_number),
+                container_title.as_ptr(),
+                tail_number.as_ptr(),
                 flight_number,
-                as_c_string!(flight_plan_path),
+                flight_plan_path.as_ptr(),
                 flight_plan_position,
                 touch_and_go as i32,
                 request_id,
@@ -313,11 +327,14 @@ impl SimConnector {
         init_pos: SIMCONNECT_DATA_INITPOSITION,
         request_id: SIMCONNECT_DATA_REQUEST_ID,
     ) -> bool {
+        let container_title = CString::new(container_title).unwrap();
+        let tail_number = CString::new(tail_number).unwrap();
+
         unsafe {
             SimConnect_AICreateNonATCAircraft(
                 self.sim_connect_handle,
-                as_c_string!(container_title),
-                as_c_string!(tail_number),
+                container_title.as_ptr(),
+                tail_number.as_ptr(),
                 init_pos,
                 request_id,
             ) == 0
@@ -330,10 +347,12 @@ impl SimConnector {
         init_pos: SIMCONNECT_DATA_INITPOSITION,
         request_id: SIMCONNECT_DATA_REQUEST_ID,
     ) -> bool {
+        let container_title = CString::new(container_title).unwrap();
+
         unsafe {
             SimConnect_AICreateSimulatedObject(
                 self.sim_connect_handle,
-                as_c_string!(container_title),
+                container_title.as_ptr(),
                 init_pos,
                 request_id,
             ) == 0
@@ -362,11 +381,13 @@ impl SimConnector {
         flight_plan_path: &str,
         request_id: SIMCONNECT_DATA_REQUEST_ID,
     ) -> bool {
+        let flight_plan_path = CString::new(flight_plan_path).unwrap();
+
         unsafe {
             SimConnect_AISetAircraftFlightPlan(
                 self.sim_connect_handle,
                 object_id,
-                as_c_string!(flight_plan_path),
+                flight_plan_path.as_ptr(),
                 request_id,
             ) == 0
         }
@@ -431,13 +452,10 @@ impl SimConnector {
         event_id: SIMCONNECT_CLIENT_EVENT_ID,
         data: DWORD,
     ) -> bool {
+        let menu_item = CString::new(menu_item).unwrap();
+
         unsafe {
-            SimConnect_MenuAddItem(
-                self.sim_connect_handle,
-                as_c_string!(menu_item),
-                event_id,
-                data,
-            ) == 0
+            SimConnect_MenuAddItem(self.sim_connect_handle, menu_item.as_ptr(), event_id, data) == 0
         }
     }
 
@@ -460,9 +478,10 @@ impl SimConnector {
         request_id: SIMCONNECT_DATA_REQUEST_ID,
         state: &str,
     ) -> bool {
+        let state = CString::new(state).unwrap();
+
         unsafe {
-            SimConnect_RequestSystemState(self.sim_connect_handle, request_id, as_c_string!(state))
-                == 0
+            SimConnect_RequestSystemState(self.sim_connect_handle, request_id, state.as_ptr()) == 0
         }
     }
 
@@ -471,10 +490,12 @@ impl SimConnector {
         client_data_name: &str,
         data_id: SIMCONNECT_CLIENT_DATA_ID,
     ) -> bool {
+        let client_data_name = CString::new(client_data_name).unwrap();
+
         unsafe {
             SimConnect_MapClientDataNameToID(
                 self.sim_connect_handle,
-                as_c_string!(client_data_name),
+                client_data_name.as_ptr(),
                 data_id,
             ) == 0
         }
@@ -553,7 +574,9 @@ impl SimConnector {
     }
 
     pub fn flight_load(&self, file_name: &str) -> bool {
-        unsafe { SimConnect_FlightLoad(self.sim_connect_handle, as_c_string!(file_name)) == 0 }
+        let file_name = CString::new(file_name).unwrap();
+
+        unsafe { SimConnect_FlightLoad(self.sim_connect_handle, file_name.as_ptr()) == 0 }
     }
 
     pub unsafe fn text(
@@ -653,11 +676,13 @@ impl SimConnector {
         event_id: SIMCONNECT_CLIENT_EVENT_ID,
         event_name: &str,
     ) -> bool {
+        let event_name = CString::new(event_name).unwrap();
+
         unsafe {
             SimConnect_SubscribeToSystemEvent(
                 self.sim_connect_handle,
                 event_id,
-                as_c_string!(event_name),
+                event_name.as_ptr(),
             ) == 0
         }
     }
@@ -667,11 +692,13 @@ impl SimConnector {
         event_id: SIMCONNECT_CLIENT_EVENT_ID,
         event_name: &str,
     ) -> bool {
+        let event_name = CString::new(event_name).unwrap();
+
         unsafe {
             SimConnect_MapClientEventToSimEvent(
                 self.sim_connect_handle,
                 event_id,
-                as_c_string!(event_name),
+                event_name.as_ptr(),
             ) == 0
         }
     }
@@ -733,11 +760,13 @@ impl SimConnector {
         up_return_value: DWORD,
         maskable: bool,
     ) -> bool {
+        let input_definition = CString::new(input_definition).unwrap();
+
         unsafe {
             SimConnect_MapInputEventToClientEvent(
                 self.sim_connect_handle,
                 group_id,
-                as_c_string!(input_definition),
+                input_definition.as_ptr(),
                 down_event,
                 down_return_value,
                 up_event,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ impl SimConnector {
                 as_c_string!(datum_name),
                 as_c_string!(units_name),
                 datum_type,
-                0.0,
+                epsilon,
                 datum_id,
             ) == 0
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,10 @@ loop {
       unsafe {
         match data.dwDefineID {
           0 => {
-            let sim_data: DataStruct = transmute_copy(&data.dwData);
-            println!("{:?} {:?} {:?}", sim_data.lat, sim_data.lon, sim_data.alt);
+            let sim_data =  std::ptr::addr_of!(data.dwData);
+            let sim_data_ptr = sim_data as *const DataStruct;
+            let sim_data_value = std::ptr::read_unaligned(sim_data_ptr);
+            println!("{:?} {:?} {:?}", sim_data_value.lat, sim_data_value.lon, sim_data_value.alt);
           },
           _ => ()
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,8 +76,8 @@ pub enum DispatchResult<'a> {
     EventObjectAddRemove(&'a SIMCONNECT_RECV_EVENT_OBJECT_ADDREMOVE),
     EventFilename(&'a SIMCONNECT_RECV_EVENT_FILENAME),
     EventFrame(&'a SIMCONNECT_RECV_EVENT_FRAME),
-    SimobjectData(&'a SIMCONNECT_RECV_SIMOBJECT_DATA),
-    SimobjectDataBytype(&'a SIMCONNECT_RECV_SIMOBJECT_DATA_BYTYPE),
+    SimObjectData(&'a SIMCONNECT_RECV_SIMOBJECT_DATA),
+    SimObjectDataByType(&'a SIMCONNECT_RECV_SIMOBJECT_DATA_BYTYPE),
     WeatherObservation(&'a SIMCONNECT_RECV_WEATHER_OBSERVATION),
     CloudState(&'a SIMCONNECT_RECV_CLOUD_STATE),
     AssignedObjectId(&'a SIMCONNECT_RECV_ASSIGNED_OBJECT_ID),
@@ -833,12 +833,12 @@ impl SimConnector {
                     )))
                 }
                 SIMCONNECT_RECV_ID_SIMCONNECT_RECV_ID_SIMOBJECT_DATA => {
-                    Ok(DispatchResult::SimobjectData(transmute_copy(
+                    Ok(DispatchResult::SimObjectData(transmute_copy(
                         &(data_buf as *const SIMCONNECT_RECV_SIMOBJECT_DATA),
                     )))
                 }
                 SIMCONNECT_RECV_ID_SIMCONNECT_RECV_ID_SIMOBJECT_DATA_BYTYPE => {
-                    Ok(DispatchResult::SimobjectDataBytype(transmute_copy(
+                    Ok(DispatchResult::SimObjectDataByType(transmute_copy(
                         &(data_buf as *const SIMCONNECT_RECV_SIMOBJECT_DATA_BYTYPE),
                     )))
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,7 @@ impl SimConnector {
         units_name: &str,
         datum_type: SIMCONNECT_DATATYPE,
         datum_id: DWORD,
+        epsilon: f32,
     ) -> bool {
         unsafe {
             SimConnect_AddToDataDefinition(
@@ -152,7 +153,7 @@ impl SimConnector {
                 as_c_string!(datum_name),
                 as_c_string!(units_name),
                 datum_type,
-                0.0,
+                epsilon,
                 datum_id,
             ) == 0
         }


### PR DESCRIPTION
## Example code fix
Fixed the example code to work with the latest Rust version regarding packed structs. The old example code couldn't compile anymore.

## Epsilon
When the epsilon of all variables in a data definition is set to 0.0, the sim will return an abundance of data when data is flagged as on change.
For example, every mm change of altitude is seen as a change in the variable, while in reality, you most likely only need changes per foot. Exposing the epsilon as a function parameter enables cleaner outputs.
This also simplifies our ability to use the data changed flag to send data to microprocessors (without flooding them with unused data).

```rust
conn.add_data_definition(0, "PLANE LATITUDE", "Degrees", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX, 0.0); // this will trigger an update every minor change < 1.0 degree
conn.add_data_definition(0, "PLANE LONGITUDE", "Degrees", simconnect::SIMCONNECT_DATATYPE_SIMCONNECT_DATATYPE_FLOAT64, u32::MAX, 1.0); // this will only trigger an update every 1.0 degree change```

