### PR TITLE
Version mismatch in the README.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@
 Add this to your `Cargo.toml`
 ```toml
 [dependencies]
-simconnect = "0.2.1"
+simconnect = "0.3.0"
 ```
 
 ## Building

--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,4 @@
+![crates.io](https://img.shields.io/crates/v/simconnect)
 # SimConnect Bindings for Rust
 ## Using
 Add this to your `Cargo.toml`


### PR DESCRIPTION
- Aligned the crate version in the README.md
- Added a shield that always displays the latest available version
![image](https://github.com/Sequal32/simconnect-rust/assets/77780263/e8290e6c-7869-4091-bc2d-29da926467a1)
